### PR TITLE
v1.1.1: defeat WP default-connector clobbering on Connectors page

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "ultimate-ai-connector-compatible-endpoints",
-	"version": "1.1.0",
+	"version": "1.1.1",
 	"private": true,
 	"license": "GPL-2.0-or-later",
 	"scripts": {

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: superdav42
 Tags: ai, connector, ollama, llm, local-ai
 Requires at least: 7.0
 Tested up to: 7.0
-Stable tag: 1.1.0
+Stable tag: 1.1.1
 Requires PHP: 7.4
 License: GPL-2.0-or-later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
@@ -72,6 +72,10 @@ Yes. WordPress 7.0 ships the AI Client SDK in core, so this connector plugin wor
 2. Model selection in the WordPress AI Client — all models from your endpoint appear automatically.
 
 == Changelog ==
+
+= 1.1.1 - Released on 2026-04-07 =
+
+* Fix: re-assert our `registerConnector()` call across multiple ticks (microtask + 0/50/250/1000 ms) so the WP core `registerDefaultConnectors()` auto-register can't clobber the custom card with the generic API-key UI. The two scripts can run in either order depending on dynamic-import resolution; this guarantees we end up last. The proper upstream fix is in https://github.com/WordPress/gutenberg/pull/77116 — once that ships in a Gutenberg release, this workaround can be removed.
 
 = 1.1.0 - Released on 2026-04-01 =
 

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -400,10 +400,31 @@ function CompatibleEndpointConnectorCard( { slug, label, description } ) {
 // Register the connector card.
 // The slug matches the provider ID used in the PHP AI Client registry so that
 // this JS registration overrides the auto-discovered entry in WP 7.0+.
-registerConnector( 'ultimate-ai-connector-compatible-endpoints', {
+const SLUG = 'ultimate-ai-connector-compatible-endpoints';
+const CONFIG = {
 	label: __( 'Compatible Endpoint' ),
 	description: __(
 		'Connect to Ollama, LM Studio, or any AI endpoint using the standard chat completions API format.'
 	),
 	render: CompatibleEndpointConnectorCard,
-} );
+};
+
+// WP core's `routes/connectors-home/content` module runs
+// `registerDefaultConnectors()` from inside an async dynamic import. By the
+// time it executes, our top-level registerConnector() has already populated
+// the store — and the store reducer spreads new config over existing
+// entries, so the default's `args.render = ApiKeyConnector` overwrites our
+// custom render. The fix in WordPress/gutenberg#77116 will solve this in
+// core, but until that lands and ships we re-assert our registration on
+// multiple ticks (sync + microtask + setTimeout 0/50/250/1000ms) to
+// guarantee we end up last regardless of dynamic-import resolution order.
+function registerOurs() {
+	registerConnector( SLUG, CONFIG );
+}
+
+registerOurs();
+Promise.resolve().then( registerOurs );
+setTimeout( registerOurs, 0 );
+setTimeout( registerOurs, 50 );
+setTimeout( registerOurs, 250 );
+setTimeout( registerOurs, 1000 );

--- a/ultimate-ai-connector-compatible-endpoints.php
+++ b/ultimate-ai-connector-compatible-endpoints.php
@@ -4,7 +4,7 @@
  * Description: Registers an AI Client provider for Ollama, LM Studio, or any AI endpoint using the standard chat completions API format.
  * Requires at least: 7.0
  * Requires PHP: 7.4
- * Version: 1.1.0
+ * Version: 1.1.1
  * Author: Ultimate Multisite Community
  * Author URI: https://ultimatemultisite.com
  * License: GPL-2.0-or-later
@@ -21,7 +21,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	return;
 }
 
-define( 'ULTIMATE_AI_CONNECTOR_COMPATIBLE_ENDPOINTS_VERSION', '1.1.0' );
+define( 'ULTIMATE_AI_CONNECTOR_COMPATIBLE_ENDPOINTS_VERSION', '1.1.1' );
 
 // ---------------------------------------------------------------------------
 // Load function files (no SDK dependency).


### PR DESCRIPTION
## What

`registerConnector()` is now re-asserted on multiple ticks so the WP core `registerDefaultConnectors()` auto-register can't clobber our custom card with the generic API-key form.

## Why

WP core's `routes/connectors-home/content` module runs `registerDefaultConnectors()` from inside an async dynamic import. By the time it executes, our top-level `registerConnector()` has already populated the connectors store. The store reducer in `@wordpress/connectors` spreads new config over the existing entry:

```js
[ action.slug ]: {
    ...state.connectors[ action.slug ],   // existing
    slug: action.slug,
    ...action.config,                      // new (wins per key)
}
```

So the default's `args.render = ApiKeyConnector` overwrites our custom render. The user sees the generic API key form instead of the endpoint URL / model picker we built.

This is a real, observed regression — see the screenshot in #(linked issue) on the sister WebLLM connector plugin where exactly the same thing was happening.

## Fix

Re-assert our registration on five ticks: sync, microtask, and `setTimeout` at 0/50/250/1000 ms. Whichever order the browser settles dynamic-import resolution in, we always end up last. Re-registering with the same render reference is idempotent so the redundant calls cost essentially nothing.

The proper upstream fix is **WordPress/gutenberg#77116** (just opened, makes `registerDefaultConnectors()` skip slugs that already have a custom render). Once that ships in a Gutenberg release, this workaround can be removed.

## Test plan

- [x] Activate this branch on a clean WordPress 7.0 install with `@wordpress/ai` plugin loaded.
- [x] Visit **Settings → Connectors** in a desktop browser.
- [x] Verify the "Compatible Endpoint" card shows the custom form (Endpoint URL / API Key / Model dropdown / Timeout) instead of the generic API Key field.
- [x] Verify the same on a fresh page load with no other plugins active that might affect script-module ordering — the previous behavior was that the bug appeared depending on which other connector plugins were enabled.

## Release

Bumps version to **1.1.1** in:
- `ultimate-ai-connector-compatible-endpoints.php` plugin header + `ULTIMATE_AI_CONNECTOR_COMPATIBLE_ENDPOINTS_VERSION` constant
- `package.json`
- `readme.txt` `Stable tag` + new changelog entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed an issue where the connector could be overridden during WordPress initialization, ensuring the connector UI remains properly registered and visible to users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->