### PR TITLE
fix: eliminate blocking HTTP request on every page load

### DIFF
--- a/inc/class-model-directory.php
+++ b/inc/class-model-directory.php
@@ -45,6 +45,94 @@ class CompatibleEndpointModelDirectory extends AbstractOpenAiCompatibleModelMeta
 	/**
 	 * {@inheritDoc}
 	 *
+	 * Wraps the parent HTTP request with a WordPress transient so the /models
+	 * endpoint is only called once per 24 hours (or until the transient expires
+	 * or is deleted). The SDK's built-in PSR-16 object-cache layer is per-
+	 * request on sites without Redis/Memcached, making it useless in standard
+	 * php-fpm or FrankenPHP environments.
+	 *
+	 * Raw model data (id + name) is stored rather than serialised ModelMetadata
+	 * objects to avoid recreating AbstractEnum instances that fail the strict
+	 * (===) singleton identity checks used by the SDK's PromptBuilder internals.
+	 *
+	 * @return array<string, ModelMetadata> Map of model ID to model metadata.
+	 */
+	protected function sendListModelsRequest(): array {
+		$endpoint_url = CompatibleEndpointProvider::$endpointUrl;
+		$cache_key    = 'ult_ai_connector_models_' . md5( $endpoint_url );
+
+		/** @var list<array{id: string, name: string}>|false $cached */
+		$cached = get_transient( $cache_key );
+
+		if ( is_array( $cached ) && ! empty( $cached ) ) {
+			return $this->buildModelMetadataMapFromRaw( $cached );
+		}
+
+		// Cache miss: make the live HTTP request via the parent implementation.
+		$map = parent::sendListModelsRequest();
+
+		if ( ! empty( $map ) ) {
+			$raw = [];
+			foreach ( $map as $metadata ) {
+				$raw[] = [
+					'id'   => $metadata->getId(),
+					'name' => $metadata->getName(),
+				];
+			}
+			set_transient( $cache_key, $raw, DAY_IN_SECONDS );
+		}
+
+		return $map;
+	}
+
+	/**
+	 * Reconstructs a model ID → ModelMetadata map from raw cached data.
+	 *
+	 * Creates fresh ModelMetadata instances (including fresh CapabilityEnum and
+	 * OptionEnum singleton instances from their factory methods) to avoid the
+	 * enum-identity problem that arises when deserialising stored objects.
+	 *
+	 * @param list<array{id: string, name: string}> $raw Cached raw model data.
+	 * @return array<string, ModelMetadata> Map of model ID to model metadata.
+	 */
+	private function buildModelMetadataMapFromRaw( array $raw ): array {
+		$capabilities = [
+			CapabilityEnum::textGeneration(),
+			CapabilityEnum::chatHistory(),
+		];
+
+		$options = [
+			new SupportedOption( OptionEnum::systemInstruction() ),
+			new SupportedOption( OptionEnum::maxTokens() ),
+			new SupportedOption( OptionEnum::temperature() ),
+			new SupportedOption( OptionEnum::topP() ),
+			new SupportedOption( OptionEnum::stopSequences() ),
+			new SupportedOption( OptionEnum::frequencyPenalty() ),
+			new SupportedOption( OptionEnum::presencePenalty() ),
+			new SupportedOption( OptionEnum::functionDeclarations() ),
+			new SupportedOption( OptionEnum::customOptions() ),
+			// Null accepted values — see parseResponseToModelMetadataList() comment.
+			new SupportedOption( OptionEnum::inputModalities() ),
+			new SupportedOption( OptionEnum::outputModalities() ),
+			new SupportedOption( OptionEnum::outputMimeType(), [ 'text/plain', 'application/json' ] ),
+			new SupportedOption( OptionEnum::outputSchema() ),
+		];
+
+		$map = [];
+		foreach ( $raw as $item ) {
+			$id   = (string) ( $item['id'] ?? '' );
+			$name = (string) ( $item['name'] ?? $id );
+			if ( '' !== $id ) {
+				$map[ $id ] = new ModelMetadata( $id, $name, $capabilities, $options );
+			}
+		}
+
+		return $map;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 *
 	 * @phpstan-type ModelsResponseData array{data?: list<array{id: string, name?: string}>}
 	 */
 	protected function parseResponseToModelMetadataList( Response $response ): array {

--- a/inc/class-provider-factory.php
+++ b/inc/class-provider-factory.php
@@ -17,7 +17,6 @@ use WordPress\AiClient\Providers\Http\Enums\RequestAuthenticationMethod;
 use WordPress\AiClient\Providers\Models\Contracts\ModelInterface;
 use WordPress\AiClient\Providers\Models\DTO\ModelMetadata;
 use WordPress\AiClient\Providers\ApiBasedImplementation\AbstractApiProvider;
-use WordPress\AiClient\Providers\ApiBasedImplementation\ListModelsApiBasedProviderAvailability;
 use WordPress\AiClient\Common\Exception\RuntimeException;
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -103,11 +102,46 @@ class DynamicCompatibleEndpointProvider extends AbstractApiProvider {
 
 	/**
 	 * {@inheritDoc}
+	 *
+	 * Returns a configuration-based availability check rather than a live HTTP
+	 * request. See CompatibleEndpointProvider::createProviderAvailability() for
+	 * full rationale — the same blocking-request hazard applies here because each
+	 * dynamic subclass is registered independently with the SDK registry.
+	 *
+	 * The endpoint URL is captured at call time via late-static binding so that
+	 * each dynamic subclass (CompatibleEndpointProvider_XYZ) returns its own
+	 * URL rather than the base class's empty default.
 	 */
 	protected static function createProviderAvailability(): ProviderAvailabilityInterface {
-		return new ListModelsApiBasedProviderAvailability(
-			static::modelMetadataDirectory()
-		);
+		// Capture via LSB — static:: resolves to the concrete dynamic subclass.
+		$endpoint_url = static::$endpointUrl;
+
+		return new class( $endpoint_url ) implements ProviderAvailabilityInterface {
+			/**
+			 * Endpoint URL captured at instantiation time.
+			 *
+			 * @var string
+			 */
+			private string $endpointUrl;
+
+			/**
+			 * Constructor.
+			 *
+			 * @param string $endpointUrl Endpoint URL from the dynamic provider class.
+			 */
+			public function __construct( string $endpointUrl ) {
+				$this->endpointUrl = $endpointUrl;
+			}
+
+			/**
+			 * Checks whether the endpoint URL is configured.
+			 *
+			 * @return bool True when the endpoint URL is non-empty.
+			 */
+			public function isConfigured(): bool {
+				return ! empty( $this->endpointUrl );
+			}
+		};
 	}
 
 	/**

--- a/inc/class-provider.php
+++ b/inc/class-provider.php
@@ -12,7 +12,6 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 use WordPress\AiClient\Providers\ApiBasedImplementation\AbstractApiProvider;
-use WordPress\AiClient\Providers\ApiBasedImplementation\ListModelsApiBasedProviderAvailability;
 use WordPress\AiClient\Providers\Contracts\ModelMetadataDirectoryInterface;
 use WordPress\AiClient\Providers\Contracts\ProviderAvailabilityInterface;
 use WordPress\AiClient\Providers\DTO\ProviderMetadata;
@@ -79,11 +78,28 @@ class CompatibleEndpointProvider extends AbstractApiProvider {
 
 	/**
 	 * {@inheritDoc}
+	 *
+	 * Returns a configuration-based availability check rather than a live HTTP
+	 * request. Using ListModelsApiBasedProviderAvailability here would fire a
+	 * blocking HTTP request to the /models endpoint on every page load where
+	 * isConfigured() is called (e.g. Connectors settings page, AI feature
+	 * discovery). On sites without a persistent object cache the SDK's internal
+	 * PSR-16 cache is cold on every request, causing 7+ second latency spikes.
+	 *
+	 * Actual endpoint reachability is validated lazily the first time the user
+	 * makes an AI generation request.
 	 */
 	protected static function createProviderAvailability(): ProviderAvailabilityInterface {
-		return new ListModelsApiBasedProviderAvailability(
-			static::modelMetadataDirectory()
-		);
+		return new class implements ProviderAvailabilityInterface {
+			/**
+			 * Checks whether the endpoint URL is configured.
+			 *
+			 * @return bool True when the endpoint URL option is non-empty.
+			 */
+			public function isConfigured(): bool {
+				return ! empty( CompatibleEndpointProvider::$endpointUrl );
+			}
+		};
 	}
 
 	/**

--- a/inc/http-filters.php
+++ b/inc/http-filters.php
@@ -14,16 +14,26 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 /**
- * Increases the HTTP timeout for requests to the configured endpoint.
+ * Increases the HTTP timeout for AI generation requests to the configured endpoint.
  *
- * Local/self-hosted LLMs can take over 30 seconds to respond, especially
- * on CPU-only hardware. The default WordPress timeout of 30s is too short.
+ * The extended timeout is applied only to chat-completions requests. The /models
+ * endpoint used for availability checks and model listing must NOT get the long
+ * timeout: a slow or unreachable endpoint would otherwise block every page load
+ * for up to 360 seconds while the SDK's isConfigured() check waits for a response.
+ *
+ * Local/self-hosted LLMs can take over 30 seconds to respond during generation,
+ * especially on CPU-only hardware, so the long timeout remains for those paths.
  *
  * @param array  $parsed_args HTTP request arguments.
  * @param string $url         Request URL.
  * @return array Modified arguments.
  */
 function increase_timeout( array $parsed_args, string $url ): array {
+	// Only extend timeout for chat completions, not model listing or other paths.
+	if ( ! str_contains( $url, '/chat/completions' ) ) {
+		return $parsed_args;
+	}
+
 	$endpoint_url = get_option( 'ultimate_ai_connector_endpoint_url', '' );
 	if ( empty( $endpoint_url ) ) {
 		return $parsed_args;

--- a/tests/php/HttpFiltersTest.php
+++ b/tests/php/HttpFiltersTest.php
@@ -69,6 +69,41 @@ class HttpFiltersTest extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test timeout is NOT extended for /models requests.
+	 *
+	 * The long timeout is only needed for generation requests. Availability
+	 * checks (which hit /models) must not block for up to 360s.
+	 */
+	public function test_timeout_unchanged_for_models_endpoint() {
+		update_option( 'ultimate_ai_connector_endpoint_url', 'http://localhost:11434/v1' );
+		update_option( 'ultimate_ai_connector_timeout', 300 );
+
+		$args   = [ 'timeout' => 30 ];
+		$result = \UltimateAiConnectorCompatibleEndpoints\increase_timeout(
+			$args,
+			'http://localhost:11434/v1/models'
+		);
+
+		$this->assertSame( 30, $result['timeout'] );
+	}
+
+	/**
+	 * Test timeout is NOT extended for other non-completions paths.
+	 */
+	public function test_timeout_unchanged_for_non_completions_path() {
+		update_option( 'ultimate_ai_connector_endpoint_url', 'http://localhost:11434/v1' );
+		update_option( 'ultimate_ai_connector_timeout', 300 );
+
+		$args   = [ 'timeout' => 30 ];
+		$result = \UltimateAiConnectorCompatibleEndpoints\increase_timeout(
+			$args,
+			'http://localhost:11434/v1/embeddings'
+		);
+
+		$this->assertSame( 30, $result['timeout'] );
+	}
+
+	/**
 	 * Test non-standard port is added to allowed ports.
 	 */
 	public function test_allow_endpoint_port() {


### PR DESCRIPTION
## Summary

Fixes the 7+ second admin page load regression caused by a blocking HTTP request to the endpoint's `/models` URL on every page load. Three-part fix:

### 1. Config-based availability check (primary fix)

**Files:** `inc/class-provider.php:92-103`, `inc/class-provider-factory.php:107-150`

Replaces `ListModelsApiBasedProviderAvailability` (which calls the live `/models` endpoint to check availability) with an anonymous class that checks only whether the endpoint URL option is non-empty. Reachability is validated lazily when the user first makes an AI generation request.

This eliminates the blocking HTTP call from every page load where `isConfigured()` is called (Connectors settings page, AI feature discovery, `AiClient::isConfigured()`).

For `DynamicCompatibleEndpointProvider`, the endpoint URL is captured via late-static binding at `createProviderAvailability()` call time and passed to the anonymous class constructor, so each dynamic subclass uses its own URL rather than the base class's empty default.

### 2. Transient-based model list cache (secondary fix)

**File:** `inc/class-model-directory.php:45-131`

Overrides `sendListModelsRequest()` to wrap the parent HTTP call with a WordPress transient (`DAY_IN_SECONDS` TTL). On cache hit the result is rebuilt from stored raw data (model IDs and names only) rather than deserialised `ModelMetadata` objects — this avoids recreating `AbstractEnum` instances that would fail the SDK's strict (`===`) singleton identity checks used by `PromptBuilder`.

On sites without Redis/Memcached the SDK's built-in PSR-16 object-cache layer is cold on every request. The transient stores to the database and survives across requests.

### 3. Scope timeout filter to `/chat/completions` (tertiary fix)

**File:** `inc/http-filters.php:26-51`

`increase_timeout()` now applies the 360s timeout only when the URL contains `/chat/completions`. Applying it to `/models` or other paths meant that a slow or unreachable endpoint would block page loads for up to 6 minutes.

## Testing

- Existing `HttpFiltersTest` passes: all test URLs already use `/chat/completions`.
- Two new test cases added: `test_timeout_unchanged_for_models_endpoint` and `test_timeout_unchanged_for_non_completions_path`.

## Verification

```bash
php -l inc/class-provider.php
php -l inc/class-model-directory.php
php -l inc/http-filters.php
php -l inc/class-provider-factory.php
npm run test:php
```

Resolves #116

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.96 plugin for [OpenCode](https://opencode.ai) v1.3.17 with claude-sonnet-4-6 spent 7m and 26,078 tokens on this as a headless worker.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Multi-provider AI connector support with enable/disable toggles for each provider
  * Updated UI to add, edit, reorder, and remove multiple AI providers
  * Per-provider configuration for endpoints, API keys, default models, and timeouts
  * Automatic provider fallback chain
  * Model caching with 24-hour expiration

* **Bug Fixes**
  * Timeout extension now applies only to chat completion requests, excluding model lookup endpoints

* **Chores**
  * Version updated to 2.0.0
  * ZIP files added to gitignore

<!-- end of auto-generated comment: release notes by coderabbit.ai -->