### PR TITLE
fix: support WP 6.9 + route multi-provider model listing per SDK provider ID (2.0.1)

### DIFF
--- a/.aidevops.json
+++ b/.aidevops.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.8.85",
+  "version": "3.15.46",
   "initialized": "2026-04-01T19:20:47Z",
   "features": {
     "planning": true,

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -13,7 +13,7 @@ concurrency:
 
 jobs:
   e2e:
-    name: Cypress E2E (WP 7.0)
+    name: Cypress E2E (WP 6.9)
     runs-on: ubuntu-latest
     timeout-minutes: 30
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        wp: ['nightly']
+        wp: ['6.9', 'nightly']
 
     services:
       mariadb:

--- a/.wp-env.json
+++ b/.wp-env.json
@@ -1,8 +1,9 @@
 {
-	"core": "WordPress/WordPress#7.0-branch",
+	"core": "WordPress/WordPress#6.9-branch",
 	"phpVersion": "8.2",
 	"plugins": [
-		"."
+		".",
+		"WordPress/gutenberg"
 	],
 	"config": {
 		"WP_DEBUG": true,
@@ -12,8 +13,12 @@
 	},
 	"env": {
 		"tests": {
-			"core": "WordPress/WordPress#7.0-branch",
+			"core": "WordPress/WordPress#6.9-branch",
 			"phpVersion": "8.2",
+			"plugins": [
+				".",
+				"WordPress/gutenberg"
+			],
 			"config": {
 				"WP_DEBUG": true,
 				"WP_DEBUG_LOG": true,

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -61,7 +61,7 @@ Config: `.wp-env.json`. Override ports: `.wp-env.override.json` (gitignored).
 
 ### Manual testing
 
-1. Ensure WordPress 7.0+ with AI Client SDK is active
+1. Ensure the AI Client SDK is available — either WordPress 7.0+ (ships in core) or WordPress 6.9 with the Gutenberg plugin (23.0+) active
 2. Activate the plugin
 3. Navigate to Settings → Connectors
 4. Configure an endpoint (e.g., `http://localhost:11434/v1` for Ollama)
@@ -268,7 +268,7 @@ The shared WordPress dev install for testing this plugin is at `../wordpress` (r
 
 - **URL**: http://wordpress.local:8080
 - **Admin**: http://wordpress.local:8080/wp-admin — `admin` / `admin`
-- **WordPress version**: 7.0-RC2
+- **WordPress version**: 6.9.4 (with Gutenberg 23.0+ providing the AI Client SDK)
 - **This plugin**: symlinked into `../wordpress/wp-content/plugins/$(basename $PWD)`
 - **Reset to clean state**: `cd ../wordpress && ./reset.sh`
 

--- a/inc/class-provider-factory.php
+++ b/inc/class-provider-factory.php
@@ -199,9 +199,10 @@ class ProviderFactory {
 	 * @return string SDK provider ID.
 	 */
 	public static function sdkProviderIdForIndex( int $index ): string {
-		return $index === 0
-			? 'ai-provider-for-any-openai-compatible'
-			: 'ai-provider-for-any-openai-compatible-' . ( $index + 1 );
+		// Delegate to the settings-level helper so there is a single source of
+		// truth for the SDK ID formula (settings.php loads unconditionally and
+		// is callable before this SDK-gated class file).
+		return sdk_provider_id_for_index( $index );
 	}
 
 	/**

--- a/inc/compat-openai-connector.php
+++ b/inc/compat-openai-connector.php
@@ -36,8 +36,18 @@ function get_default_model(): string {
 /**
  * Proxy to the plugin's REST model listing function.
  *
- * Called by the AI Agent's SettingsController to populate the model dropdown
- * for providers whose ID starts with 'ai-provider-for-any-openai-compatible'.
+ * Called by the AI Agent's SettingsController and ModelsCommand to populate
+ * model lists for providers whose SDK ID starts with
+ * 'ai-provider-for-any-openai-compatible'.
+ *
+ * Supported request params (set via $request->set_param() at the call site):
+ * - 'provider_id'  Optional SDK provider ID (e.g. 'ai-provider-for-any-openai-compatible-2').
+ *                  When provided, the matching configured provider's endpoint URL and API
+ *                  key are used. Without it, the call falls back to the primary provider,
+ *                  which causes every OpenAI-compatible provider in a multi-provider setup
+ *                  to incorrectly return the same model list.
+ * - 'endpoint_url' Optional explicit endpoint URL override.
+ * - 'api_key'      Optional explicit API key override.
  *
  * @param \WP_REST_Request $request REST request (may have no params when called
  *                                  internally; falls back to primary provider).

--- a/inc/rest-api.php
+++ b/inc/rest-api.php
@@ -37,6 +37,11 @@ function register_models_route(): void {
 					'type'              => 'string',
 					'sanitize_callback' => 'sanitize_text_field',
 				],
+				'provider_id'  => [
+					'required'          => false,
+					'type'              => 'string',
+					'sanitize_callback' => 'sanitize_text_field',
+				],
 			],
 		]
 	);
@@ -51,14 +56,28 @@ function register_models_route(): void {
 function rest_list_models( \WP_REST_Request $request ) {
 	$endpoint_url = $request->get_param( 'endpoint_url' );
 	$api_key      = $request->get_param( 'api_key' );
+	$provider_id  = $request->get_param( 'provider_id' );
 
 	if ( empty( $endpoint_url ) ) {
-		// Try multi-provider config first (v2.0.0+).
-		$primary = get_primary_provider();
-		if ( $primary ) {
-			$endpoint_url = $primary['endpoint_url'] ?? '';
+		// Resolution order:
+		// 1. If a specific SDK provider ID was requested, look up that provider.
+		//    This is the multi-provider path used by the AI Agent loop and the
+		//    `wp sd-ai-agent models --provider=...` CLI command — without this,
+		//    every OpenAI-compatible provider would resolve to the same primary
+		//    config and the agent would see duplicate model lists.
+		// 2. Otherwise, fall back to the highest-priority configured provider.
+		// 3. Finally, fall back to the legacy single-provider option.
+		$resolved = null;
+		if ( ! empty( $provider_id ) ) {
+			$resolved = get_provider_by_sdk_id( (string) $provider_id );
+		}
+		if ( null === $resolved ) {
+			$resolved = get_primary_provider();
+		}
+		if ( $resolved ) {
+			$endpoint_url = $resolved['endpoint_url'] ?? '';
 			if ( null === $api_key ) {
-				$api_key = $primary['api_key'] ?? '';
+				$api_key = $resolved['api_key'] ?? '';
 			}
 		} else {
 			// Fall back to legacy single-provider option.

--- a/inc/settings.php
+++ b/inc/settings.php
@@ -210,6 +210,59 @@ function get_provider( string $id ): ?array {
 }
 
 /**
+ * Compute the SDK-level provider ID for a given registration order index.
+ *
+ * Mirrors ProviderFactory::sdkProviderIdForIndex(). Duplicated here so it can
+ * be called before SDK-dependent class files are loaded (settings.php loads
+ * unconditionally; class-provider-factory.php is gated on SDK availability).
+ *
+ * @param int $index 0-based registration index.
+ * @return string SDK provider ID.
+ */
+function sdk_provider_id_for_index( int $index ): string {
+	return 0 === $index
+		? 'ai-provider-for-any-openai-compatible'
+		: 'ai-provider-for-any-openai-compatible-' . ( $index + 1 );
+}
+
+/**
+ * Get a provider config by its SDK-level provider ID.
+ *
+ * SDK provider IDs are derived from registration order:
+ * - Index 0: 'ai-provider-for-any-openai-compatible'
+ * - Index N: 'ai-provider-for-any-openai-compatible-' . (N + 1)
+ *
+ * This mirrors ProviderFactory::sdkProviderIdForIndex() and only walks the
+ * subset of providers that actually get registered (i.e. enabled and with a
+ * non-empty endpoint_url), matching the iteration in
+ * ProviderFactory::registerAllProviders().
+ *
+ * @param string $sdk_provider_id SDK-level provider ID.
+ * @return array|null Provider config or null when no match.
+ */
+function get_provider_by_sdk_id( string $sdk_provider_id ): ?array {
+	if ( '' === $sdk_provider_id ) {
+		return null;
+	}
+
+	$ordered = get_providers_ordered();
+	$index   = 0;
+	foreach ( $ordered as $provider ) {
+		if ( empty( $provider['endpoint_url'] ) || ! ( $provider['enabled'] ?? true ) ) {
+			continue;
+		}
+
+		$candidate_sdk_id = sdk_provider_id_for_index( $index );
+		if ( $candidate_sdk_id === $sdk_provider_id ) {
+			return $provider;
+		}
+		++$index;
+	}
+
+	return null;
+}
+
+/**
  * Get providers in fallback order (first = highest priority).
  *
  * @return array Ordered list of provider configs.

--- a/readme.txt
+++ b/readme.txt
@@ -82,6 +82,7 @@ Yes, provided the Gutenberg plugin (version 23.0 or later) is active. Gutenberg 
 
 * Improved: Lowered minimum WordPress requirement to 6.9 to match the upstream `ai-provider-for-openai` pattern. The plugin loads safely as a no-op until the AI Client SDK becomes available (via WordPress 7.0+ core or a sibling plugin that bundles `wordpress/php-ai-client`, e.g. Superdav AI Agent).
 * Fix: Defer SDK-dependent class loading to `plugins_loaded:5` so SDKs registered by alphabetically-later plugins (e.g. Superdav AI Agent on WP 6.9) are detected. Previously the SDK guard ran at file-include time, before later plugins had a chance to register their autoloader.
+* Fix: Multi-provider model listing now correctly returns each provider's own models. Previously the REST `/models` callback (and the `OpenAiCompatibleConnector\rest_list_models()` compatibility shim used by the AI Agent) always fell back to the primary provider's endpoint, so every OpenAI-compatible provider in a multi-provider setup showed the same model list. Callers can now pass a `provider_id` request param (the SDK provider ID, e.g. `ai-provider-for-any-openai-compatible-2`) to resolve the correct per-provider endpoint and API key. Note: the AI Agent plugin must also be updated to pass this param — without that companion change, the agent will still see the primary provider's models.
 
 = 2.0.0 - Released on 2026-04-24 =
 

--- a/readme.txt
+++ b/readme.txt
@@ -1,7 +1,7 @@
 === Ultimate AI Connector for Compatible Endpoints ===
 Contributors: superdav42
 Tags: ai, connector, ollama, llm, local-ai
-Requires at least: 7.0
+Requires at least: 6.9
 Tested up to: 7.0
 Stable tag: 2.0.0
 Requires PHP: 7.4
@@ -27,6 +27,7 @@ This plugin extends the WordPress AI Client to support **any AI service or serve
 **Requirements:**
 
 * **WordPress 7.0+** - The AI Client SDK is included in core. This plugin works on its own without any additional dependencies.
+* **WordPress 6.9** - Also supported when the Gutenberg plugin (23.0+) is active, which provides the AI Client SDK.
 
 **Why it matters:**
 
@@ -66,12 +67,21 @@ The plugin automatically queries your endpoint's `/models` resource and register
 
 Yes. WordPress 7.0 ships the AI Client SDK in core, so this connector plugin works on its own. You only need the AI Experiments plugin if you want the experimental AI features it provides (excerpt generation, summarization, etc.).
 
+= Can I use this on WordPress 6.9? =
+
+Yes, provided the Gutenberg plugin (version 23.0 or later) is active. Gutenberg ships the AI Client SDK that this connector extends. If the SDK is not present, the connector loads safely as a no-op and exposes no provider until the SDK becomes available.
+
 == Screenshots ==
 
 1. The Connectors settings page — enter your endpoint URL, optional API key, and default model.
 2. Model selection in the WordPress AI Client — all models from your endpoint appear automatically.
 
 == Changelog ==
+
+= 2.0.1 =
+
+* Improved: Lowered minimum WordPress requirement to 6.9 to match the upstream `ai-provider-for-openai` pattern. The plugin loads safely as a no-op until the AI Client SDK becomes available (via WordPress 7.0+ core or a sibling plugin that bundles `wordpress/php-ai-client`, e.g. Superdav AI Agent).
+* Fix: Defer SDK-dependent class loading to `plugins_loaded:5` so SDKs registered by alphabetically-later plugins (e.g. Superdav AI Agent on WP 6.9) are detected. Previously the SDK guard ran at file-include time, before later plugins had a chance to register their autoloader.
 
 = 2.0.0 - Released on 2026-04-24 =
 

--- a/tests/php/MultiProviderRoutingTest.php
+++ b/tests/php/MultiProviderRoutingTest.php
@@ -1,0 +1,304 @@
+<?php
+/**
+ * Test multi-provider routing of model-listing requests.
+ *
+ * Regression coverage for the v2.0.0 multi-provider bug where every
+ * OpenAI-compatible provider returned the same (primary) model list because
+ * \UltimateAiConnectorCompatibleEndpoints\rest_list_models() always fell back
+ * to get_primary_provider() when the request did not carry an explicit
+ * endpoint URL.
+ *
+ * @package UltimateAiConnectorCompatibleEndpoints
+ * @license GPL-2.0-or-later
+ */
+
+namespace UltimateAiConnectorCompatibleEndpoints\Tests;
+
+use WP_UnitTestCase;
+use WP_REST_Request;
+
+use function UltimateAiConnectorCompatibleEndpoints\get_provider_by_sdk_id;
+use function UltimateAiConnectorCompatibleEndpoints\sdk_provider_id_for_index;
+
+/**
+ * Multi-provider routing tests.
+ */
+class MultiProviderRoutingTest extends WP_UnitTestCase {
+
+	/**
+	 * Captured outgoing HTTP request URLs, keyed by call order.
+	 *
+	 * Populated by the pre_http_request short-circuit filter so tests can
+	 * assert that the correct per-provider /models URL was requested.
+	 *
+	 * @var list<string>
+	 */
+	private array $captured_urls = [];
+
+	/**
+	 * Stub /models response payload returned by the http filter.
+	 *
+	 * Distinct payload per endpoint URL so tests can prove the right one
+	 * was hit and the right body was returned to the caller.
+	 *
+	 * @var array<string, list<array{id: string, name: string}>>
+	 */
+	private array $stub_responses = [];
+
+	/**
+	 * Tear down: clear options and remove HTTP filter.
+	 */
+	public function tear_down(): void {
+		delete_option( 'ultimate_ai_connector_providers' );
+		delete_option( 'ultimate_ai_connector_provider_order' );
+		delete_option( 'ultimate_ai_connector_endpoint_url' );
+		delete_option( 'ultimate_ai_connector_api_key' );
+		remove_all_filters( 'pre_http_request' );
+		$this->captured_urls  = [];
+		$this->stub_responses = [];
+		parent::tear_down();
+	}
+
+	/**
+	 * Configure two distinct providers and install the stub HTTP filter.
+	 */
+	private function set_up_two_providers(): void {
+		update_option(
+			'ultimate_ai_connector_providers',
+			[
+				[
+					'id'            => 'provider_alpha',
+					'name'          => 'Alpha (Ollama)',
+					'endpoint_url'  => 'http://alpha.example.test/v1',
+					'api_key'       => 'alpha-key',
+					'default_model' => '',
+					'timeout'       => 360,
+					'enabled'       => true,
+				],
+				[
+					'id'            => 'provider_beta',
+					'name'          => 'Beta (Synthetic)',
+					'endpoint_url'  => 'https://beta.example.test/v1',
+					'api_key'       => 'beta-key',
+					'default_model' => 'beta-model',
+					'timeout'       => 360,
+					'enabled'       => true,
+				],
+			]
+		);
+
+		// Distinct payloads so equality assertions prove the right host was hit.
+		$this->stub_responses = [
+			'http://alpha.example.test/v1/models' => [
+				[
+					'id'   => 'alpha-model-1',
+					'name' => 'alpha-model-1',
+				],
+				[
+					'id'   => 'alpha-model-2',
+					'name' => 'alpha-model-2',
+				],
+			],
+			'https://beta.example.test/v1/models' => [
+				[
+					'id'   => 'beta-only-model',
+					'name' => 'beta-only-model',
+				],
+			],
+		];
+
+		add_filter( 'pre_http_request', [ $this, 'short_circuit_http' ], 10, 3 );
+	}
+
+	/**
+	 * Short-circuit /models HTTP requests with stub data.
+	 *
+	 * @param mixed  $pre  Filtered value (false to allow real request).
+	 * @param array  $args Request args.
+	 * @param string $url  Request URL.
+	 * @return array|mixed Stubbed wp_remote_get response or $pre.
+	 */
+	public function short_circuit_http( $pre, $args, $url ) {
+		$this->captured_urls[] = $url;
+
+		if ( ! isset( $this->stub_responses[ $url ] ) ) {
+			return $pre;
+		}
+
+		return [
+			'headers'  => [],
+			'body'     => wp_json_encode( [ 'data' => $this->stub_responses[ $url ] ] ),
+			'response' => [
+				'code'    => 200,
+				'message' => 'OK',
+			],
+			'cookies'  => [],
+			'filename' => null,
+		];
+	}
+
+	/**
+	 * SDK index 0 maps to the bare ID; index N>0 gets a numeric suffix.
+	 */
+	public function test_sdk_provider_id_for_index_formula() {
+		$this->assertSame( 'ai-provider-for-any-openai-compatible', sdk_provider_id_for_index( 0 ) );
+		$this->assertSame( 'ai-provider-for-any-openai-compatible-2', sdk_provider_id_for_index( 1 ) );
+		$this->assertSame( 'ai-provider-for-any-openai-compatible-3', sdk_provider_id_for_index( 2 ) );
+	}
+
+	/**
+	 * get_provider_by_sdk_id() resolves the registration-order index.
+	 */
+	public function test_get_provider_by_sdk_id_resolves_each_provider() {
+		$this->set_up_two_providers();
+
+		$alpha = get_provider_by_sdk_id( 'ai-provider-for-any-openai-compatible' );
+		$beta  = get_provider_by_sdk_id( 'ai-provider-for-any-openai-compatible-2' );
+
+		$this->assertNotNull( $alpha );
+		$this->assertSame( 'http://alpha.example.test/v1', $alpha['endpoint_url'] );
+		$this->assertSame( 'alpha-key', $alpha['api_key'] );
+
+		$this->assertNotNull( $beta );
+		$this->assertSame( 'https://beta.example.test/v1', $beta['endpoint_url'] );
+		$this->assertSame( 'beta-key', $beta['api_key'] );
+
+		// Unknown SDK ID must return null, not silently fall back.
+		$this->assertNull( get_provider_by_sdk_id( 'ai-provider-for-any-openai-compatible-99' ) );
+		$this->assertNull( get_provider_by_sdk_id( '' ) );
+	}
+
+	/**
+	 * Disabled providers are skipped, but registration-order indexing still
+	 * matches what ProviderFactory::registerAllProviders() actually registers.
+	 */
+	public function test_get_provider_by_sdk_id_skips_disabled_providers() {
+		update_option(
+			'ultimate_ai_connector_providers',
+			[
+				[
+					'id'           => 'p_disabled',
+					'name'         => 'Disabled',
+					'endpoint_url' => 'http://disabled.example.test/v1',
+					'api_key'      => 'd-key',
+					'enabled'      => false,
+				],
+				[
+					'id'           => 'p_real_first',
+					'name'         => 'Real first',
+					'endpoint_url' => 'http://first.example.test/v1',
+					'api_key'      => 'first-key',
+					'enabled'      => true,
+				],
+				[
+					'id'           => 'p_real_second',
+					'name'         => 'Real second',
+					'endpoint_url' => 'http://second.example.test/v1',
+					'api_key'      => 'second-key',
+					'enabled'      => true,
+				],
+			]
+		);
+
+		$first = get_provider_by_sdk_id( 'ai-provider-for-any-openai-compatible' );
+		$this->assertNotNull( $first );
+		$this->assertSame( 'p_real_first', $first['id'] );
+
+		$second = get_provider_by_sdk_id( 'ai-provider-for-any-openai-compatible-2' );
+		$this->assertNotNull( $second );
+		$this->assertSame( 'p_real_second', $second['id'] );
+	}
+
+	/**
+	 * REGRESSION: With provider_id set, each provider's request must hit
+	 * its own endpoint and return its own model list.
+	 *
+	 * Pre-fix behaviour: both calls returned the primary provider's models
+	 * because the param was ignored and get_primary_provider() always won.
+	 */
+	public function test_rest_list_models_routes_per_provider_id() {
+		$this->set_up_two_providers();
+
+		$req_alpha = new WP_REST_Request( 'GET' );
+		$req_alpha->set_param( 'provider_id', 'ai-provider-for-any-openai-compatible' );
+		$resp_alpha = \UltimateAiConnectorCompatibleEndpoints\rest_list_models( $req_alpha );
+
+		$req_beta = new WP_REST_Request( 'GET' );
+		$req_beta->set_param( 'provider_id', 'ai-provider-for-any-openai-compatible-2' );
+		$resp_beta = \UltimateAiConnectorCompatibleEndpoints\rest_list_models( $req_beta );
+
+		$this->assertNotInstanceOf( \WP_Error::class, $resp_alpha );
+		$this->assertNotInstanceOf( \WP_Error::class, $resp_beta );
+
+		$alpha_data = $resp_alpha->get_data();
+		$beta_data  = $resp_beta->get_data();
+
+		$alpha_ids = array_column( $alpha_data, 'id' );
+		$beta_ids  = array_column( $beta_data, 'id' );
+
+		// Each provider returns its OWN distinct model set.
+		$this->assertSame( [ 'alpha-model-1', 'alpha-model-2' ], $alpha_ids );
+		$this->assertSame( [ 'beta-only-model' ], $beta_ids );
+
+		// Each request hit its own /models URL.
+		$this->assertContains( 'http://alpha.example.test/v1/models', $this->captured_urls );
+		$this->assertContains( 'https://beta.example.test/v1/models', $this->captured_urls );
+	}
+
+	/**
+	 * The compat shim under \OpenAiCompatibleConnector\rest_list_models()
+	 * — the function the AI Agent actually calls — must honour provider_id.
+	 */
+	public function test_compat_shim_routes_per_provider_id() {
+		$this->set_up_two_providers();
+
+		$this->assertTrue( function_exists( 'OpenAiCompatibleConnector\\rest_list_models' ) );
+
+		$req = new WP_REST_Request( 'GET' );
+		$req->set_param( 'provider_id', 'ai-provider-for-any-openai-compatible-2' );
+		$resp = \OpenAiCompatibleConnector\rest_list_models( $req );
+
+		$this->assertNotInstanceOf( \WP_Error::class, $resp );
+		$this->assertSame( [ 'beta-only-model' ], array_column( $resp->get_data(), 'id' ) );
+	}
+
+	/**
+	 * Backwards-compat: when no provider_id is supplied, behaviour is
+	 * unchanged — the primary (highest-priority) provider wins.
+	 *
+	 * This protects callers that were already on the legacy contract.
+	 */
+	public function test_rest_list_models_falls_back_to_primary_when_no_provider_id() {
+		$this->set_up_two_providers();
+
+		$req  = new WP_REST_Request( 'GET' );
+		$resp = \UltimateAiConnectorCompatibleEndpoints\rest_list_models( $req );
+
+		$this->assertNotInstanceOf( \WP_Error::class, $resp );
+
+		// Alpha is registered first → primary → its models are returned.
+		$this->assertSame(
+			[ 'alpha-model-1', 'alpha-model-2' ],
+			array_column( $resp->get_data(), 'id' )
+		);
+	}
+
+	/**
+	 * Explicit endpoint_url in the request continues to take absolute precedence
+	 * over both provider_id and primary fallback.
+	 */
+	public function test_explicit_endpoint_url_overrides_provider_id() {
+		$this->set_up_two_providers();
+
+		$req = new WP_REST_Request( 'GET' );
+		$req->set_param( 'provider_id', 'ai-provider-for-any-openai-compatible' );
+		$req->set_param( 'endpoint_url', 'https://beta.example.test/v1' );
+		$resp = \UltimateAiConnectorCompatibleEndpoints\rest_list_models( $req );
+
+		$this->assertNotInstanceOf( \WP_Error::class, $resp );
+		$this->assertSame(
+			[ 'beta-only-model' ],
+			array_column( $resp->get_data(), 'id' )
+		);
+	}
+}

--- a/ultimate-ai-connector-compatible-endpoints.php
+++ b/ultimate-ai-connector-compatible-endpoints.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: Ultimate AI Connector for Compatible Endpoints
  * Description: Registers an AI Client provider for Ollama, LM Studio, or any AI endpoint using the standard chat completions API format.
- * Requires at least: 7.0
+ * Requires at least: 6.9
  * Requires PHP: 7.4
  * Version: 2.0.0
  * Author: Ultimate Multisite Community
@@ -36,18 +36,48 @@ require_once __DIR__ . '/inc/compat-openai-connector.php';
 // ---------------------------------------------------------------------------
 // Load SDK-dependent class files only when the AI Client SDK is available.
 // These files extend SDK abstract classes and will fatal if loaded without it.
+//
+// On WordPress 7.0+ the SDK ships in core, so it's available at plugin
+// file-include time. On WordPress 6.9 the SDK arrives via another plugin
+// (e.g. superdav-ai-agent's bundled wordpress/php-ai-client) which may load
+// AFTER us due to alphabetic plugin load order. We therefore defer the
+// SDK-class load to `plugins_loaded:5` — late enough for any provider
+// plugin to have registered the SDK autoloader, but early enough that our
+// `init:5` provider registration still runs.
 // ---------------------------------------------------------------------------
 
-if ( class_exists( 'WordPress\\AiClient\\Providers\\ApiBasedImplementation\\AbstractApiProvider' ) ) {
+/**
+ * Loads SDK-dependent class files when the AI Client SDK is available.
+ *
+ * Safe to call multiple times: each include uses require_once, and the SDK
+ * presence check short-circuits when the SDK never becomes available.
+ *
+ * @return void
+ */
+function load_sdk_dependent_classes(): void {
+	if ( ! class_exists( 'WordPress\\AiClient\\Providers\\ApiBasedImplementation\\AbstractApiProvider' ) ) {
+		return;
+	}
+
 	require_once __DIR__ . '/inc/class-provider.php';
 	require_once __DIR__ . '/inc/class-model.php';
 	require_once __DIR__ . '/inc/class-model-directory.php';
 	require_once __DIR__ . '/inc/class-provider-factory.php';
 	require_once __DIR__ . '/inc/provider-registration.php';
+
+	// Provider registration only runs when SDK classes are loaded.
+	if ( function_exists( __NAMESPACE__ . '\\register_provider' ) ) {
+		add_action( 'init', __NAMESPACE__ . '\\register_provider', 5 );
+	}
 }
 
+// Try once at file-load time (WP 7.0+ in-core SDK path), and again at
+// plugins_loaded:5 to catch SDKs registered by later-loading plugins on WP 6.9.
+load_sdk_dependent_classes();
+add_action( 'plugins_loaded', __NAMESPACE__ . '\\load_sdk_dependent_classes', 5 );
+
 // ---------------------------------------------------------------------------
-// Hook registrations.
+// Hook registrations (SDK-independent).
 // ---------------------------------------------------------------------------
 
 // Settings.
@@ -63,8 +93,3 @@ add_action( 'rest_api_init', __NAMESPACE__ . '\\register_models_route' );
 add_filter( 'http_request_args', __NAMESPACE__ . '\\increase_timeout', 10, 2 );
 add_filter( 'http_allowed_safe_ports', __NAMESPACE__ . '\\allow_endpoint_port' );
 add_filter( 'http_request_host_is_external', __NAMESPACE__ . '\\allow_endpoint_host', 10, 2 );
-
-// Provider registration (only when SDK classes are available).
-if ( function_exists( __NAMESPACE__ . '\\register_provider' ) ) {
-	add_action( 'init', __NAMESPACE__ . '\\register_provider', 5 );
-}


### PR DESCRIPTION
## Summary

This PR contains the changes intended for the upcoming **2.0.1** release:

1. **Fix multi-provider model listing routing.** The user-facing symptom is that two distinct providers (e.g. an Ollama and a Synthetic endpoint) report the *same* model list — both showing whichever set belongs to the primary provider. The root cause and fix are described below.
2. **Lower minimum WordPress requirement to 6.9** (was 7.0). The plugin now loads safely as a no-op until the AI Client SDK becomes available, either from WordPress 7.0+ core or from a sibling plugin that bundles `wordpress/php-ai-client` (e.g. Superdav AI Agent / Gutenberg 23.0+).
3. **CI matrix + dev env** updated to test against WP 6.9 and use Gutenberg as the SDK source under wp-env.
4. Bookkeeping: `.aidevops.json` framework version marker bump.

## The multi-provider routing bug

### Repro

With two distinct providers configured (different URLs, different keys):

```
$ wp sd-ai-agent models
| ai-provider-for-any-openai-compatible   | ollama    | server | 17 |
| ai-provider-for-any-openai-compatible-2 | synthetic | server | 17 |

$ wp sd-ai-agent models --provider=ai-provider-for-any-openai-compatible
… 17 ollama models …

$ wp sd-ai-agent models --provider=ai-provider-for-any-openai-compatible-2
… same 17 ollama models …  ← bug: should be the synthetic provider's list
```

### Cause

`\UltimateAiConnectorCompatibleEndpoints\rest_list_models()` and its compat shim `\OpenAiCompatibleConnector\rest_list_models()` always fell back to `get_primary_provider()` when the inbound request carried no explicit `endpoint_url`. The AI Agent calls the shim from two sites with a bare `WP_REST_Request('GET')` — no provider context — so the connector had no way to know which of the registered SDK providers (`ai-provider-for-any-openai-compatible`, `…-2`, `…-3`, …) the call was for, and every call resolved to the primary endpoint.

Generation routing was already correct (`CompatibleEndpointModel::createRequest()` resolves the per-provider URL via `self::$endpointUrls[ $provider_id ]`) — only the listing path through the compat shim was broken.

### Fix

- `rest_list_models()` and the compat shim now honour a new `provider_id` request param holding the SDK-level provider ID (e.g. `ai-provider-for-any-openai-compatible-2`). When set, the matching configured provider is resolved by registration-order index and its endpoint URL + API key are used.
- Adds `get_provider_by_sdk_id()` and `sdk_provider_id_for_index()` helpers in `inc/settings.php` so resolution works before the SDK-gated class files load. `ProviderFactory::sdkProviderIdForIndex()` now delegates to the canonical settings helper (single source of truth).
- Behaviour is a strict superset: callers that don't pass `provider_id` keep the existing primary-fallback semantics, so no existing caller breaks.

### Companion change required in superdav-ai-agent

The connector fix is necessary but not sufficient for the user-visible CLI to start showing distinct model lists. The agent must pass the provider context it already has in scope:

- `includes/CLI/ModelsCommand.php:209` — change `new \WP_REST_Request( 'GET' )` to set `provider_id` from the loop variable.
- `includes/REST/SettingsController.php:781` — same change at the second call site.

Two-line patch sketch:

```php
$req = new \WP_REST_Request( 'GET' );
$req->set_param( 'provider_id', $provider_id );
$result = \OpenAiCompatibleConnector\rest_list_models( $req );
```

I'll open a matching PR on `superdav-ai-agent` once this lands so the contract on both sides ships together.

## WP 6.9 compat

On WP 7.0+ the AI Client SDK ships in core and is available at plugin file-include time. On WP 6.9 the SDK is provided by another plugin (e.g. Superdav AI Agent's bundled `wordpress/php-ai-client`), which loads alphabetically after this plugin. SDK-dependent class files are now loaded by `load_sdk_dependent_classes()` which runs both at file-include time (WP 7.0+ path) and again at `plugins_loaded:5` (WP 6.9 sibling-plugin path). Provider registration is hooked from inside the loader so it only runs when SDK classes are actually present.

## Tests

- New: `tests/php/MultiProviderRoutingTest.php` — 7 cases covering the SDK ID formula, by-SDK-ID lookup (including disabled-provider skipping), per-provider routing through both the namespace function and the compat shim, backwards-compat primary fallback, and explicit `endpoint_url` precedence.
- Full suite: **27 tests, 89 assertions, all passing** (PHPUnit 9.6.34, WP 6.9 test fixture).
- PHPStan: zero new errors introduced (baseline 121 pre-existing SDK class-not-found warnings unchanged).

## Files changed

| Area | Files |
|------|-------|
| Multi-provider fix | `inc/settings.php`, `inc/rest-api.php`, `inc/compat-openai-connector.php`, `inc/class-provider-factory.php` |
| Tests | `tests/php/MultiProviderRoutingTest.php` |
| WP 6.9 compat | `ultimate-ai-connector-compatible-endpoints.php`, `readme.txt`, `AGENTS.md` |
| CI / dev env | `.github/workflows/tests.yml`, `.github/workflows/e2e.yml`, `.wp-env.json` |
| Bookkeeping | `.aidevops.json` |

## Pre-release checklist

Before tagging 2.0.1, the plugin file `Version:` header (still `2.0.0`) and `Stable tag:` in `readme.txt` need to be bumped to `2.0.1`. Intentionally not done in this PR so the version bump can be a single, reviewable release commit.

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.50 plugin for [OpenCode](https://opencode.ai) v1.14.50 with claude-sonnet-4-6 spent 8h 59m and 383 tokens on this as a headless worker.
