### PR TITLE
fix: scope SDK model-directory cache key per endpoint URL

### DIFF
--- a/inc/class-model-directory.php
+++ b/inc/class-model-directory.php
@@ -49,6 +49,26 @@ class CompatibleEndpointModelDirectory extends AbstractOpenAiCompatibleModelMeta
 
 	/**
 	 * {@inheritDoc}
+	 *
+	 * Mixes the endpoint URL into the base cache key so each configured
+	 * provider gets its own SDK PSR-16 cache slot.
+	 *
+	 * The parent implementation keys the cache on `static::class` alone, which
+	 * is fine for built-in single-endpoint providers but causes a critical
+	 * cross-provider collision for us: every dynamic Compatible Endpoint
+	 * provider (Ollama, synthetic.new, LM Studio, OpenRouter, …) shares the
+	 * one `CompatibleEndpointModelDirectory` class. Without this override the
+	 * first provider to populate the SDK cache poisons every subsequent
+	 * provider's model lookup with the wrong model list — manifesting as e.g.
+	 * an Ollama model id being POSTed to synthetic.new's chat/completions
+	 * endpoint.
+	 */
+	protected function getBaseCacheKey(): string {
+		return parent::getBaseCacheKey() . '_' . md5( $this->endpointUrl );
+	}
+
+	/**
+	 * {@inheritDoc}
 	 */
 	protected function createRequest(
 		HttpMethodEnum $method,

--- a/tests/php/MultiProviderRoutingTest.php
+++ b/tests/php/MultiProviderRoutingTest.php
@@ -301,4 +301,46 @@ class MultiProviderRoutingTest extends WP_UnitTestCase {
 			array_column( $resp->get_data(), 'id' )
 		);
 	}
+
+	/**
+	 * REGRESSION: Each ModelMetadataDirectory instance must use a cache key
+	 * scoped to its endpoint URL.
+	 *
+	 * Pre-fix behaviour: the SDK PSR-16 cache key was derived from
+	 * `static::class` alone. Because every Compatible Endpoint provider shares
+	 * the same directory class, the first endpoint to populate the SDK cache
+	 * poisoned every subsequent endpoint's model map — manifesting in the wild
+	 * as an Ollama model id being POSTed to synthetic.new's chat/completions
+	 * endpoint (HTTP 400 "Your model name should start with an hf: prefix").
+	 *
+	 * This test reproduces the collision directly: two directories with
+	 * distinct endpoint URLs must produce distinct base cache keys.
+	 */
+	public function test_directory_cache_key_includes_endpoint_url() {
+		$sdk_parent = 'WordPress\\AiClient\\Providers\\OpenAiCompatibleImplementation\\AbstractOpenAiCompatibleModelMetadataDirectory';
+		if ( ! class_exists( $sdk_parent, false ) ) {
+			$this->markTestSkipped( 'AI Client SDK not available in this test environment.' );
+		}
+
+		$directory_class = 'UltimateAiConnectorCompatibleEndpoints\\CompatibleEndpointModelDirectory';
+		$alpha           = new $directory_class( 'http://alpha.example.test/v1' );
+		$beta            = new $directory_class( 'https://beta.example.test/v1' );
+
+		// Reach getBaseCacheKey() via reflection (protected on the SDK base).
+		$key_method = ( new \ReflectionClass( $alpha ) )->getMethod( 'getBaseCacheKey' );
+		$key_method->setAccessible( true );
+
+		$alpha_key = $key_method->invoke( $alpha );
+		$beta_key  = $key_method->invoke( $beta );
+
+		$this->assertNotSame( $alpha_key, $beta_key, 'Different endpoints must yield different cache keys.' );
+
+		// Same endpoint URL must yield the same key (cache stability).
+		$alpha_dup = new CompatibleEndpointModelDirectory( 'http://alpha.example.test/v1' );
+		$this->assertSame( $alpha_key, $key_method->invoke( $alpha_dup ) );
+
+		// Trailing slash normalised so http://x/v1/ and http://x/v1 share a slot.
+		$alpha_slash = new CompatibleEndpointModelDirectory( 'http://alpha.example.test/v1/' );
+		$this->assertSame( $alpha_key, $key_method->invoke( $alpha_slash ) );
+	}
 }


### PR DESCRIPTION
## Summary

Fixes a critical cross-provider cache collision that caused requests for one configured endpoint (e.g. synthetic.new) to be sent with model ids from a different endpoint (e.g. Ollama), surfacing as confusing upstream 400 errors such as `"Your model name should start with an hf: prefix"`.

## Root cause

The SDK's `AbstractApiBasedModelMetadataDirectory::getBaseCacheKey()` keys its PSR-16 model-list cache on `static::class` alone:

```php
protected function getBaseCacheKey(): string {
    return 'ai_client_' . AiClient::VERSION . '_' . md5(static::class);
}
```

Every Compatible Endpoint provider configured in this plugin shares the single `CompatibleEndpointModelDirectory` class, so they all collide on the same cache slot.

Failure mode reproduced via `wp sd-ai-agent prompt`:
1. AgentLoop (or any prior code path) populates the SDK cache from Ollama's `/v1/models`.
2. AgentLoop calls `$registry->getProviderModel('ai-provider-for-any-openai-compatible-2', 'hf:moonshotai/Kimi-K2.6')` for the synthetic provider.
3. The SDK cache HIT returns Ollama's model map. Lookup throws `InvalidArgumentException`.
4. AgentLoop's catch falls back to `$builder->using_provider($provider_id)` only.
5. PromptBuilder picks the first candidate from the (still-Ollama) cached list — `hf.co/unsloth/Qwen3.6-35B-A3B-GGUF:UD-Q4_K_M`.
6. `POST https://api.synthetic.new/openai/v1/chat/completions` with `model: hf.co/unsloth/...` → 400 from Synthetic.

The endpoint URL was already correct (each dynamic provider class carries its own URL); only the model metadata was wrong because of the shared SDK cache slot.

## Fix

Override `getBaseCacheKey()` in `CompatibleEndpointModelDirectory` to mix the endpoint URL hash into the SDK cache key so each configured endpoint gets its own slot:

```php
protected function getBaseCacheKey(): string {
    return parent::getBaseCacheKey() . '_' . md5( $this->endpointUrl );
}
```

## Tests

New regression test `MultiProviderRoutingTest::test_directory_cache_key_includes_endpoint_url`:

- Distinct endpoints → distinct cache keys.
- Identical endpoints → identical keys (cache stability).
- Trailing-slash variants normalised to the same key.
- Skipped automatically when the AI Client SDK isn't loaded in the test WP install.

`vendor/bin/phpunit` — 27 pass, 1 skipped (SDK-only test), 0 failures.

## Manual verification

```sh
# Pre-fix: synthetic call fails with the wrong-model 400.
wp sd-ai-agent prompt "say hi" \
  --provider=ai-provider-for-any-openai-compatible-2 \
  --model="hf:moonshotai/Kimi-K2.6"
# Warning: Bad Request (400) - Your model name should start with an hf: prefix; …

# Post-fix: succeeds; outbound body has the requested model id.
wp sd-ai-agent prompt "say hi" \
  --provider=ai-provider-for-any-openai-compatible-2 \
  --model="hf:moonshotai/Kimi-K2.6"
# Hi there! 👋 I'm your WordPress assistant …
```

Confirmed via debug HTTP logger that `POST https://api.synthetic.new/openai/v1/chat/completions` now goes out with `"model":"hf:moonshotai/Kimi-K2.6"`. Ollama path remains unaffected.

## Files

- `inc/class-model-directory.php` — fix (+20 lines)
- `tests/php/MultiProviderRoutingTest.php` — regression test (+42 lines)

## Notes

- No SDK upstream changes required; clean override of a `protected` method.
- No user-facing behaviour change beyond the bug being fixed.
- Backwards-compatible: existing cached entries from the pre-fix key won't be read, but they'll just be repopulated on first use under the new key.

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.52 plugin for [OpenCode](https://opencode.ai) v1.15.0 with claude-sonnet-4-6 spent 20h 10m and 383 tokens on this as a headless worker.
