### PR TITLE
fix: consolidate per-provider connector cards into a single card

### DIFF
--- a/inc/provider-registration.php
+++ b/inc/provider-registration.php
@@ -15,6 +15,23 @@ use WordPress\AiClient\AiClient;
 use WordPress\AiClient\Providers\Http\DTO\ApiKeyRequestAuthentication;
 
 /**
+ * Connector ID rendered by our JS module (src/index.jsx SLUG constant).
+ *
+ * This single slug represents the plugin in the Settings > Connectors UI.
+ * Each per-provider entry the SDK auto-discovers under
+ * `ai-provider-for-any-openai-compatible[-N]` is collapsed into this card.
+ */
+const CONNECTOR_SLUG = 'ultimate-ai-connector-compatible-endpoints';
+
+/**
+ * Prefix used by all SDK provider IDs this plugin registers.
+ *
+ * Mirrors sdk_provider_id_for_index() in settings.php — the primary provider
+ * uses this exact ID and additional providers append `-2`, `-3`, etc.
+ */
+const SDK_PROVIDER_ID_PREFIX = 'ai-provider-for-any-openai-compatible';
+
+/**
  * Registers the provider(s) with the AI Client on init.
  *
  * Runs at priority 5 so the provider is available before most plugins act on
@@ -63,6 +80,69 @@ function register_provider(): void {
 		CompatibleEndpointProvider::class,
 		new ApiKeyRequestAuthentication( $api_key )
 	);
+}
+
+/**
+ * Collapses per-provider connector cards into a single card for this plugin.
+ *
+ * The Connectors UI (Gutenberg `_gutenberg_register_default_ai_providers`,
+ * priority 15 on `init`) iterates `AiClient::defaultRegistry()` and registers
+ * one connector card per registered SDK provider. Because this plugin
+ * registers a dedicated SDK provider for every endpoint the user configures
+ * (ollama, synthetic, etc.), every configured endpoint surfaces as its own
+ * "new connector to configure" card — which is misleading: those providers
+ * are already managed inside this plugin's single card.
+ *
+ * This callback runs on `wp_connectors_init` (fired at the end of
+ * `_gutenberg_connectors_init`, priority 15). We:
+ *
+ * 1. Unregister every connector whose ID starts with the SDK provider prefix
+ *    used by this plugin (`ai-provider-for-any-openai-compatible[-N]`).
+ * 2. Register a single canonical connector keyed by the slug our React
+ *    component is registered under in `src/index.jsx` — this lets the JS
+ *    `registerConnector( SLUG, CONFIG )` actually override the default render
+ *    and present the multi-provider management UI.
+ *
+ * The SDK registry itself is left untouched: text generation and fallback
+ * routing across all configured providers continue to work.
+ *
+ * @param \WP_Connector_Registry $registry Connector registry instance.
+ */
+function consolidate_connector_card( \WP_Connector_Registry $registry ): void {
+	if ( ! class_exists( AiClient::class ) ) {
+		return;
+	}
+
+	// Drop the auto-discovered per-provider duplicates.
+	$prefix      = SDK_PROVIDER_ID_PREFIX;
+	$ai_registry = AiClient::defaultRegistry();
+	foreach ( $ai_registry->getRegisteredProviderIds() as $sdk_provider_id ) {
+		if ( 0 !== strpos( (string) $sdk_provider_id, $prefix ) ) {
+			continue;
+		}
+		if ( $registry->is_registered( $sdk_provider_id ) ) {
+			$registry->unregister( $sdk_provider_id );
+		}
+	}
+
+	// Register a single canonical card matching the JS SLUG so the React
+	// component in src/index.jsx renders in place of the default form.
+	if ( ! $registry->is_registered( CONNECTOR_SLUG ) ) {
+		$registry->register(
+			CONNECTOR_SLUG,
+			[
+				'name'           => __( 'Compatible Endpoint', 'ultimate-ai-connector-compatible-endpoints' ),
+				'description'    => __(
+					'Connect to Ollama, LM Studio, or any AI endpoint using the standard chat completions API format.',
+					'ultimate-ai-connector-compatible-endpoints'
+				),
+				'type'           => 'ai_provider',
+				'authentication' => [
+					'method' => 'none',
+				],
+			]
+		);
+	}
 }
 
 /**

--- a/ultimate-ai-connector-compatible-endpoints.php
+++ b/ultimate-ai-connector-compatible-endpoints.php
@@ -69,6 +69,13 @@ function load_sdk_dependent_classes(): void {
 	if ( function_exists( __NAMESPACE__ . '\\register_provider' ) ) {
 		add_action( 'init', __NAMESPACE__ . '\\register_provider', 5 );
 	}
+
+	// Consolidate the auto-discovered per-provider connector cards into a
+	// single card managed by our React component. Runs on wp_connectors_init,
+	// which fires after Gutenberg's default-connectors registration (init:15).
+	if ( function_exists( __NAMESPACE__ . '\\consolidate_connector_card' ) ) {
+		add_action( 'wp_connectors_init', __NAMESPACE__ . '\\consolidate_connector_card' );
+	}
 }
 
 // Try once at file-load time (WP 7.0+ in-core SDK path), and again at


### PR DESCRIPTION
## Summary

The Settings > Connectors page was showing each configured provider (ollama, synthetic, etc.) as a separate "new connector to configure" card alongside the plugin's own card — so users saw N+1 cards instead of one.

## Root cause

This plugin registers a dedicated AI Client SDK provider for every endpoint the user configures, with IDs `ai-provider-for-any-openai-compatible`, `…-2`, `…-3`. Gutenberg's `_gutenberg_register_default_ai_providers()` (init priority 15) iterates the SDK registry and registers one connector card per provider. The React component in `src/index.jsx` was registered under a different slug (`ultimate-ai-connector-compatible-endpoints`), so it didn't override any of those entries — it just added an extra card on top.

## Fix

Hook `wp_connectors_init` to:

1. Unregister every connector whose ID starts with `ai-provider-for-any-openai-compatible` (clears the per-provider duplicates).
2. Register a single canonical connector keyed by the same slug the JS module uses, so the React multi-provider UI renders in place of the default form.

The SDK registry itself is left untouched — text generation and fallback routing across all configured providers continue to work exactly as before. Only the admin UI changes.

## Verification

- `php -l` clean on both modified files.
- `npm run build` succeeds.
- Runtime check confirms the `wp_connectors_init` callback is registered with the expected fully-qualified name.
- Manual: on a wp-env install with multiple providers configured, only the single "ANY LLM" card now appears; the per-provider "ollama"/"synthetic" duplicate cards are gone.

## Notes

- No new PHPUnit tests added — `WP_Connector_Registry` is a Gutenberg-experimental class not stubbed in the test bootstrap; adding coverage would require mocking the registry. Manual + runtime verification is in line with how other connector-page wiring is currently tested.

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.54 plugin for [OpenCode](https://opencode.ai) v1.15.0 with claude-sonnet-4-6 spent 1d 3h and 383 tokens on this as a headless worker.
