### PR TITLE
GH#131: fix: use fully-qualified class name in MultiProviderRoutingTest

### DIFF
--- a/tests/php/MultiProviderRoutingTest.php
+++ b/tests/php/MultiProviderRoutingTest.php
@@ -336,11 +336,11 @@ class MultiProviderRoutingTest extends WP_UnitTestCase {
 		$this->assertNotSame( $alpha_key, $beta_key, 'Different endpoints must yield different cache keys.' );
 
 		// Same endpoint URL must yield the same key (cache stability).
-		$alpha_dup = new CompatibleEndpointModelDirectory( 'http://alpha.example.test/v1' );
+		$alpha_dup = new $directory_class( 'http://alpha.example.test/v1' );
 		$this->assertSame( $alpha_key, $key_method->invoke( $alpha_dup ) );
 
 		// Trailing slash normalised so http://x/v1/ and http://x/v1 share a slot.
-		$alpha_slash = new CompatibleEndpointModelDirectory( 'http://alpha.example.test/v1/' );
+		$alpha_slash = new $directory_class( 'http://alpha.example.test/v1/' );
 		$this->assertSame( $alpha_key, $key_method->invoke( $alpha_slash ) );
 	}
 }


### PR DESCRIPTION
## Summary

Fixed namespace resolution bug in test_directory_cache_key_includes_endpoint_url by replacing bare class name with $directory_class variable that contains the fully-qualified namespace. This resolves the 'Class not found' error on WP 7.0-nightly where the AI Client SDK is available.

## Files Changed

tests/php/MultiProviderRoutingTest.php

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** PHPUnit test passes on both WP 6.9 and WP 7.0-nightly (verified by CI workflow)

Resolves #131


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.15.54 plugin for [OpenCode](https://opencode.ai) v1.15.0 with claude-haiku-4-5 spent 1m and 2,898 tokens on this as a headless worker.