### PR TITLE
fix: avoid cached model metadata DTOs

### DIFF
--- a/inc/class-model-directory.php
+++ b/inc/class-model-directory.php
@@ -11,14 +11,20 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
+use WordPress\AiClient\Common\Exception\InvalidArgumentException;
+use WordPress\AiClient\Providers\Contracts\ModelMetadataDirectoryInterface;
+use WordPress\AiClient\Providers\Http\Contracts\WithHttpTransporterInterface;
+use WordPress\AiClient\Providers\Http\Contracts\WithRequestAuthenticationInterface;
 use WordPress\AiClient\Providers\Http\DTO\Request;
 use WordPress\AiClient\Providers\Http\DTO\Response;
 use WordPress\AiClient\Providers\Http\Enums\HttpMethodEnum;
+use WordPress\AiClient\Providers\Http\Traits\WithHttpTransporterTrait;
+use WordPress\AiClient\Providers\Http\Traits\WithRequestAuthenticationTrait;
+use WordPress\AiClient\Providers\Http\Util\ResponseUtil;
 use WordPress\AiClient\Providers\Models\DTO\ModelMetadata;
 use WordPress\AiClient\Providers\Models\DTO\SupportedOption;
 use WordPress\AiClient\Providers\Models\Enums\CapabilityEnum;
 use WordPress\AiClient\Providers\Models\Enums\OptionEnum;
-use WordPress\AiClient\Providers\OpenAiCompatibleImplementation\AbstractOpenAiCompatibleModelMetadataDirectory;
 
 /**
  * Lists available models from the configured endpoint's /models resource.
@@ -26,7 +32,10 @@ use WordPress\AiClient\Providers\OpenAiCompatibleImplementation\AbstractOpenAiCo
  * Accepts an optional endpoint URL so that each dynamic provider can pass its
  * own URL rather than falling back to the legacy single-provider static.
  */
-class CompatibleEndpointModelDirectory extends AbstractOpenAiCompatibleModelMetadataDirectory {
+class CompatibleEndpointModelDirectory implements ModelMetadataDirectoryInterface, WithHttpTransporterInterface, WithRequestAuthenticationInterface {
+
+	use WithHttpTransporterTrait;
+	use WithRequestAuthenticationTrait;
 
 	/**
 	 * The base URL for this directory instance.
@@ -39,6 +48,19 @@ class CompatibleEndpointModelDirectory extends AbstractOpenAiCompatibleModelMeta
 	private string $endpointUrl;
 
 	/**
+	 * Request-local model metadata cache.
+	 *
+	 * This intentionally stays in PHP memory only. The SDK parent directory
+	 * persists ModelMetadata DTOs into the WordPress object cache, which can be
+	 * deserialized as __PHP_Incomplete_Class by some persistent cache backends or
+	 * after AI Client class-loading/version changes. Persist raw model IDs/names in
+	 * the plugin transient instead and rebuild fresh DTOs for each request.
+	 *
+	 * @var array<string, ModelMetadata>|null
+	 */
+	private ?array $modelMetadataMap = null;
+
+	/**
 	 * @param string $endpointUrl Base URL of the AI endpoint (no trailing slash).
 	 */
 	public function __construct( string $endpointUrl = '' ) {
@@ -49,28 +71,56 @@ class CompatibleEndpointModelDirectory extends AbstractOpenAiCompatibleModelMeta
 
 	/**
 	 * {@inheritDoc}
-	 *
-	 * Mixes the endpoint URL into the base cache key so each configured
-	 * provider gets its own SDK PSR-16 cache slot.
-	 *
-	 * The parent implementation keys the cache on `static::class` alone, which
-	 * is fine for built-in single-endpoint providers but causes a critical
-	 * cross-provider collision for us: every dynamic Compatible Endpoint
-	 * provider (Ollama, synthetic.new, LM Studio, OpenRouter, …) shares the
-	 * one `CompatibleEndpointModelDirectory` class. Without this override the
-	 * first provider to populate the SDK cache poisons every subsequent
-	 * provider's model lookup with the wrong model list — manifesting as e.g.
-	 * an Ollama model id being POSTed to synthetic.new's chat/completions
-	 * endpoint.
 	 */
-	protected function getBaseCacheKey(): string {
-		return parent::getBaseCacheKey() . '_' . md5( $this->endpointUrl );
+	public function listModelMetadata(): array {
+		return array_values( $this->getModelMetadataMap() );
 	}
 
 	/**
 	 * {@inheritDoc}
 	 */
-	protected function createRequest(
+	public function hasModelMetadata( string $modelId ): bool {
+		$models_metadata = $this->getModelMetadataMap();
+
+		return isset( $models_metadata[ $modelId ] );
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function getModelMetadata( string $modelId ): ModelMetadata {
+		$models_metadata = $this->getModelMetadataMap();
+
+		if ( ! isset( $models_metadata[ $modelId ] ) ) {
+			throw new InvalidArgumentException( sprintf( 'No model with ID %s was found in the provider', $modelId ) );
+		}
+
+		return $models_metadata[ $modelId ];
+	}
+
+	/**
+	 * Returns a request-local map of model ID to model metadata.
+	 *
+	 * @return array<string, ModelMetadata> Map of model ID to model metadata.
+	 */
+	private function getModelMetadataMap(): array {
+		if ( null === $this->modelMetadataMap ) {
+			$this->modelMetadataMap = $this->sendListModelsRequest();
+		}
+
+		return $this->modelMetadataMap;
+	}
+
+	/**
+	 * Creates a request for the endpoint API.
+	 *
+	 * @param HttpMethodEnum                 $method HTTP method.
+	 * @param string                         $path API path relative to endpoint URL.
+	 * @param array<string, string|string[]> $headers Request headers.
+	 * @param string|array<string, mixed>|null $data Request data.
+	 * @return Request Request DTO.
+	 */
+	private function createRequest(
 		HttpMethodEnum $method,
 		string $path,
 		array $headers = [],
@@ -85,21 +135,21 @@ class CompatibleEndpointModelDirectory extends AbstractOpenAiCompatibleModelMeta
 	}
 
 	/**
-	 * {@inheritDoc}
+	 * Sends the /models request and returns a map of model metadata.
 	 *
-	 * Wraps the parent HTTP request with a WordPress transient so the /models
+	 * Wraps the HTTP request with a WordPress transient so the /models
 	 * endpoint is only called once per 24 hours (or until the transient expires
-	 * or is deleted). The SDK's built-in PSR-16 object-cache layer is per-
-	 * request on sites without Redis/Memcached, making it useless in standard
-	 * php-fpm or FrankenPHP environments.
+	 * or is deleted).
 	 *
 	 * Raw model data (id + name) is stored rather than serialised ModelMetadata
-	 * objects to avoid recreating AbstractEnum instances that fail the strict
-	 * (===) singleton identity checks used by the SDK's PromptBuilder internals.
+	 * objects to avoid persistent object-cache deserialization into
+	 * __PHP_Incomplete_Class and to avoid recreating AbstractEnum instances that
+	 * fail the strict (===) singleton identity checks used by the SDK's
+	 * PromptBuilder internals.
 	 *
 	 * @return array<string, ModelMetadata> Map of model ID to model metadata.
 	 */
-	protected function sendListModelsRequest(): array {
+	private function sendListModelsRequest(): array {
 		$endpoint_url = $this->endpointUrl;
 		$cache_key    = 'ult_ai_connector_models_' . md5( $endpoint_url );
 
@@ -110,8 +160,17 @@ class CompatibleEndpointModelDirectory extends AbstractOpenAiCompatibleModelMeta
 			return $this->buildModelMetadataMapFromRaw( $cached );
 		}
 
-		// Cache miss: make the live HTTP request via the parent implementation.
-		$map = parent::sendListModelsRequest();
+		// Cache miss: make the live HTTP request.
+		$http_transporter = $this->getHttpTransporter();
+		$request          = $this->createRequest( HttpMethodEnum::GET(), 'models' );
+		$request          = $this->getRequestAuthentication()->authenticateRequest( $request );
+		$response         = $http_transporter->send( $request );
+		ResponseUtil::throwIfNotSuccessful( $response );
+
+		$map = [];
+		foreach ( $this->parseResponseToModelMetadataList( $response ) as $metadata ) {
+			$map[ $metadata->getId() ] = $metadata;
+		}
 
 		if ( ! empty( $map ) ) {
 			$raw = [];
@@ -173,11 +232,13 @@ class CompatibleEndpointModelDirectory extends AbstractOpenAiCompatibleModelMeta
 	}
 
 	/**
-	 * {@inheritDoc}
+	 * Parses the API models response into model metadata DTOs.
 	 *
 	 * @phpstan-type ModelsResponseData array{data?: list<array{id: string, name?: string}>}
+	 * @param Response $response Response from the models endpoint.
+	 * @return list<ModelMetadata> List of model metadata DTOs.
 	 */
-	protected function parseResponseToModelMetadataList( Response $response ): array {
+	private function parseResponseToModelMetadataList( Response $response ): array {
 		/** @var ModelsResponseData $responseData */
 		$responseData = $response->getData();
 

--- a/tests/php/MultiProviderRoutingTest.php
+++ b/tests/php/MultiProviderRoutingTest.php
@@ -303,44 +303,63 @@ class MultiProviderRoutingTest extends WP_UnitTestCase {
 	}
 
 	/**
-	 * REGRESSION: Each ModelMetadataDirectory instance must use a cache key
-	 * scoped to its endpoint URL.
+	 * REGRESSION: The directory must not use the SDK's persistent DTO cache.
 	 *
-	 * Pre-fix behaviour: the SDK PSR-16 cache key was derived from
-	 * `static::class` alone. Because every Compatible Endpoint provider shares
-	 * the same directory class, the first endpoint to populate the SDK cache
-	 * poisoned every subsequent endpoint's model map — manifesting in the wild
-	 * as an Ollama model id being POSTed to synthetic.new's chat/completions
-	 * endpoint (HTTP 400 "Your model name should start with an hf: prefix").
+	 * Pre-fix behaviour: the SDK parent directory persisted ModelMetadata DTOs in
+	 * the WordPress object cache. Some persistent cache backends, class-loading
+	 * orders, or AI Client upgrades can hydrate those cached DTOs as
+	 * __PHP_Incomplete_Class. The AI Client then passes them into
+	 * ModelRequirements::areMetBy(), causing a TypeError during features such as
+	 * ai/meta-description and ai/content-classification.
 	 *
-	 * This test reproduces the collision directly: two directories with
-	 * distinct endpoint URLs must produce distinct base cache keys.
+	 * The connector should persist only raw model IDs/names in its own transient
+	 * and rebuild fresh ModelMetadata DTOs at read time.
 	 */
-	public function test_directory_cache_key_includes_endpoint_url() {
-		$sdk_parent = 'WordPress\\AiClient\\Providers\\OpenAiCompatibleImplementation\\AbstractOpenAiCompatibleModelMetadataDirectory';
-		if ( ! class_exists( $sdk_parent, false ) ) {
+	public function test_directory_ignores_poisoned_sdk_model_metadata_cache() {
+		$sdk_cache_interface = 'WordPress\\AiClient\\Common\\Contracts\\CachesDataInterface';
+		$model_metadata      = 'WordPress\\AiClient\\Providers\\Models\\DTO\\ModelMetadata';
+		if ( ! interface_exists( $sdk_cache_interface, false ) || ! class_exists( $model_metadata, false ) ) {
 			$this->markTestSkipped( 'AI Client SDK not available in this test environment.' );
 		}
 
+		$endpoint        = 'http://alpha.example.test/v1';
 		$directory_class = 'UltimateAiConnectorCompatibleEndpoints\\CompatibleEndpointModelDirectory';
-		$alpha           = new $directory_class( 'http://alpha.example.test/v1' );
-		$beta            = new $directory_class( 'https://beta.example.test/v1' );
+		$directory       = new $directory_class( $endpoint );
 
-		// Reach getBaseCacheKey() via reflection (protected on the SDK base).
-		$key_method = ( new \ReflectionClass( $alpha ) )->getMethod( 'getBaseCacheKey' );
-		$key_method->setAccessible( true );
+		$this->assertNotInstanceOf(
+			$sdk_cache_interface,
+			$directory,
+			'CompatibleEndpointModelDirectory must not opt into the SDK persistent DTO cache.'
+		);
 
-		$alpha_key = $key_method->invoke( $alpha );
-		$beta_key  = $key_method->invoke( $beta );
+		$raw_cache_key = 'ult_ai_connector_models_' . md5( $endpoint );
+		set_transient(
+			$raw_cache_key,
+			[
+				[
+					'id'   => 'alpha-model-1',
+					'name' => 'Alpha Model 1',
+				],
+			],
+			DAY_IN_SECONDS
+		);
 
-		$this->assertNotSame( $alpha_key, $beta_key, 'Different endpoints must yield different cache keys.' );
+		$sdk_cache_key = 'ai_client_' . \WordPress\AiClient\AiClient::VERSION
+			. '_' . md5( $directory_class )
+			. '_' . md5( $endpoint )
+			. '_models';
+		$poisoned      = @unserialize( 'O:24:"Missing_Model_Metadata_X":0:{}' );
+		wp_cache_set( $sdk_cache_key, [ 'poisoned' => $poisoned ], 'wp_ai_client', DAY_IN_SECONDS );
 
-		// Same endpoint URL must yield the same key (cache stability).
-		$alpha_dup = new $directory_class( 'http://alpha.example.test/v1' );
-		$this->assertSame( $alpha_key, $key_method->invoke( $alpha_dup ) );
+		try {
+			$models = $directory->listModelMetadata();
+		} finally {
+			delete_transient( $raw_cache_key );
+			wp_cache_delete( $sdk_cache_key, 'wp_ai_client' );
+		}
 
-		// Trailing slash normalised so http://x/v1/ and http://x/v1 share a slot.
-		$alpha_slash = new $directory_class( 'http://alpha.example.test/v1/' );
-		$this->assertSame( $alpha_key, $key_method->invoke( $alpha_slash ) );
+		$this->assertCount( 1, $models );
+		$this->assertInstanceOf( $model_metadata, $models[0] );
+		$this->assertSame( 'alpha-model-1', $models[0]->getId() );
 	}
 }


### PR DESCRIPTION
## Summary

- Replace the connector model directory's SDK parent-cache dependency with a direct `ModelMetadataDirectoryInterface` implementation.
- Keep `ModelMetadata` DTOs request-local only, while continuing to cache raw model IDs/names in the connector transient.
- Add regression coverage for poisoned SDK object-cache entries hydrating as `__PHP_Incomplete_Class`.

## Testing

- `php -l` for all tracked PHP files
- `wp --path=/home/dave/Git/wordpress eval ...` poisoned-cache generation smoke test: returned `Generated test meta description.`, requests `models,chat`, `directory_uses_sdk_cache=no`
- `agent-browser` on `http://wordpress.local:8080/wp-admin/options-connectors.php`: Connectors admin page loads with the fix worktree symlinked into the local WordPress install
- `npm run build`

## Notes

- `npm run test:php -- --filter MultiProviderRoutingTest` is blocked locally by the WordPress PHPUnit DB config: `Access denied for user 'root'@'localhost'`.

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.19.0 plugin for [OpenCode](https://opencode.ai) v1.15.10 with gpt-5.5 spent 1h 19m and 14,327 tokens on this as a headless worker.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Optimized model metadata caching mechanism to improve query responsiveness and reliability when retrieving available models.

* **Tests**
  * Updated test coverage to verify proper model metadata cache behavior and data freshness validation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Ultimate-Multisite/ultimate-ai-connector-compatible-endpoints/pull/137?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->