### PR TITLE
GH#138: fix: load AI Client classes in SDK guard

### DIFF
--- a/tests/php/MultiProviderRoutingTest.php
+++ b/tests/php/MultiProviderRoutingTest.php
@@ -318,7 +318,8 @@ class MultiProviderRoutingTest extends WP_UnitTestCase {
 	public function test_directory_ignores_poisoned_sdk_model_metadata_cache() {
 		$sdk_cache_interface = 'WordPress\\AiClient\\Common\\Contracts\\CachesDataInterface';
 		$model_metadata      = 'WordPress\\AiClient\\Providers\\Models\\DTO\\ModelMetadata';
-		if ( ! interface_exists( $sdk_cache_interface, false ) || ! class_exists( $model_metadata, false ) ) {
+		$ai_client_class     = 'WordPress\\AiClient\\AiClient';
+		if ( ! interface_exists( $sdk_cache_interface ) || ! class_exists( $model_metadata ) || ! class_exists( $ai_client_class ) ) {
 			$this->markTestSkipped( 'AI Client SDK not available in this test environment.' );
 		}
 


### PR DESCRIPTION
## Summary

Updated the poisoned SDK metadata cache regression test guard to allow AI Client SDK classes/interfaces to autoload and to verify the AiClient class before dereferencing AiClient::VERSION.

## Files Changed

tests/php/MultiProviderRoutingTest.php

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** php -l tests/php/MultiProviderRoutingTest.php (pass); npm run test:php -- --filter test_directory_ignores_poisoned_sdk_model_metadata_cache (blocked: phpunit command not installed in environment)

Resolves #138


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.19.2 plugin for [OpenCode](https://opencode.ai) v1.15.10 with gpt-5.5 spent 1m and 31,485 tokens on this as a headless worker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test environment validation to ensure all required dependencies are available before execution.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Ultimate-Multisite/ultimate-ai-connector-compatible-endpoints/pull/139?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->